### PR TITLE
Allow a $tweet object to be passed to linkify()

### DIFF
--- a/src/Thujohn/Twitter/Twitter.php
+++ b/src/Thujohn/Twitter/Twitter.php
@@ -190,6 +190,11 @@ class Twitter extends tmhOAuth
 
 	public function linkify( $tweet )
 	{
+		if(is_object($tweet))
+		{
+			$tweet = $tweet->text;
+		}
+
 		$tweet = ' ' . $tweet;
 
 		$patterns             = [ ];

--- a/tests/Thujohn/Twitter/TwitterTest.php
+++ b/tests/Thujohn/Twitter/TwitterTest.php
@@ -244,4 +244,16 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testLinkify()
+    {
+        $string = '@user posted an awesome #tweet hit me up: me@example.com http://example.com http://some.com/really/long/url/with/many/many/levels.jpg?query=yes';
+        $object = new stdClass();
+        $object->text = $string;
+        $expected = '<a href="https://twitter.com/user" target="_blank">@user</a> posted an awesome  <a href="https://twitter.com/search?q=%23tweet" target="_blank">#tweet</a> hit me up: <a href="mailto:me@example.com">me@example.com</a> <a href="http://example.com" target="_blank" rel="nofollow">http://example.com</a> <a href="http://some.com/really/long/url/with/many/many/levels.jpg?query=yes" target="_blank" rel="nofollow">some.com/really/long/u...jpg?query=yes</a>';
+        $t = $this->getTwitter();
+        $sOut = $t->linkify($string);
+        $oOut = $t->linkify($object);
+        $this->assertEquals($expected, $sOut);
+        $this->assertEquals($expected, $oOut);
+    }
 }


### PR DESCRIPTION
As per my comments in #66, I thought it would be nice to allow `lankify()` to accept a $tweet object as with other functions.